### PR TITLE
Avoid 404 response for new get messages API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -257,9 +257,8 @@ creates unless a set of principles was registered for the queue.
                    prefix the hex message with the partition number and a
                    colon.
 
-    Get messages by their message ids from a queue. If some of the messages
-    aren't found they are omitted from the result. If no message can be
-    found a 404 Not Found is returned.
+    Get messages by their message ids from a queue. This API acts as a search,
+    so any message that cannot be found is omitted from the result.
 
     Example response::
 

--- a/queuey/resources.py
+++ b/queuey/resources.py
@@ -29,11 +29,6 @@ class InvalidMessageID(Exception):
     status = 400
 
 
-class MessageIDNotFound(Exception):
-    """Raised when message ID's aren't found"""
-    status = 404
-
-
 def transform_stored_message(message):
     del message['metadata']
     message['partition'] = int(message['queue_name'].split(':')[-1])
@@ -261,8 +256,6 @@ class MessageBatch(object):
                     results.append(res)
         self.queue.metlog.incr('%s.get_message' % self.queue.application,
             count=len(results))
-        if not results:
-            raise MessageIDNotFound("Message ID not found.")
         return results
 
     def update(self, params):

--- a/queuey/tests/test_integrated.py
+++ b/queuey/tests/test_integrated.py
@@ -262,8 +262,9 @@ class TestQueueyBaseApp(unittest.TestCase):
         # Fetch a non-existing message
         fake = '3%3A' + uuid.uuid1().hex
         resp = app.get('/v1/queuey/%s/%s' % (queue_name, fake),
-            headers=auth_header, status=404)
-        eq_(404, resp.status_int)
+            headers=auth_header)
+        result = json.loads(resp.body)
+        eq_(0, len(result['messages']))
 
         # Fetch first message
         resp = app.get('/v1/queuey/%s/%s' % (queue_name, messages[0]),

--- a/queuey/views.py
+++ b/queuey/views.py
@@ -34,7 +34,6 @@ class UJSONRendererFactory:
 @view_config(context='queuey.resources.InvalidQueueName')
 @view_config(context='queuey.resources.InvalidUpdate')
 @view_config(context='queuey.resources.InvalidMessageID')
-@view_config(context='queuey.resources.MessageIDNotFound')
 @view_config(context='queuey.storage.StorageUnavailable')
 def bad_params(context, request):
     exc = request.exception


### PR DESCRIPTION
Treating the whole new GET API as a type of search makes more sense. So it'll always return a 200 with a potentially empty result['messages'] now.

Requesting a single message feels a bit more like a resource request, but it all gets unclear once you request two messages and either none or just one of them exists.
