### PR TITLE
message timestamp precision - use decimal

### DIFF
--- a/dev-reqs.txt
+++ b/dev-reqs.txt
@@ -10,6 +10,7 @@ Pygments==1.5
 WebOb==1.2b3
 WebTest==1.3.3
 argparse==1.2.1
+cdecimal==2.3
 cef==0.3
 colander==0.9.7
 coverage==3.5.1

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,11 +142,17 @@ Message Management
 ==================
 
 Create messages on a queue, get messages, and delete messages. Access varies
-depending on the queue, queues with a type of ``public`` 
+depending on the queue, queues with a type of ``public``
 may have messages viewed without any authentication. All other queue's require
 an Application key to create messages, and viewing messages varies depending
 on queue principles. By default an Application may create/view messages it
 creates unless a set of principles was registered for the queue.
+
+Responses containing messages include a message `timestamp`. The value is in
+seconds since the epoch in GMT. It uses a precision down to multiples of 100
+nanoseconds. The precision matches that of UUID1s used for the `message_id`.
+Note that double precision floating point numbers don't guarantee enough
+significant decimal digits to represent those numbers accurately.
 
 .. http:method:: GET /v1/{application}/{queue_name}
 
@@ -154,7 +160,8 @@ creates unless a set of principles was registered for the queue.
     :arg queue_name: Queue name to access
     :optparam since: All messages newer than this timestamp *or* message id.
                      Should be formatted as seconds since epoch in GMT, or the
-                     hexadecimal message ID.
+                     hexadecimal message id. For exact results with single
+                     message accuracy use the hexadecimal message id.
     :optparam limit: Only return N amount of messages.
     :optparam order: Order of messages, can be set to either `ascending` or
                      `descending`. Defaults to `ascending`.

--- a/queuey/resources.py
+++ b/queuey/resources.py
@@ -2,13 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import collections
+from decimal import Decimal
 import re
 
 from pyramid.security import Allow
 from pyramid.security import Everyone
 
 
-FLOAT_REGEX = re.compile(r'^\d+(\.\d+)?')
+DECIMAL_REGEX = re.compile(r'^\d+(\.\d+)?')
 MESSAGE_REGEX = re.compile(
     r'(?:\d\:)?[a-zA-Z0-9]{32}(?:\,(?:\d{1,3}\:)?[a-zA-Z0-9]{32}){0,}'
 )
@@ -198,8 +199,8 @@ class Queue(object):
         queue_names = []
         for part in partitions:
             queue_names.append('%s:%s' % (self.queue_name, part))
-        if since and FLOAT_REGEX.match(since):
-            since = float(since)
+        if since and DECIMAL_REGEX.match(since):
+            since = Decimal(since)
         results = self.storage.retrieve_batch(
             self.consistency, self.application, queue_names, start_at=since,
             limit=limit, order=order)

--- a/queuey/resources.py
+++ b/queuey/resources.py
@@ -9,7 +9,7 @@ from pyramid.security import Allow
 from pyramid.security import Everyone
 
 
-DECIMAL_REGEX = re.compile(r'^\d+(\.\d+)?')
+DECIMAL_REGEX = re.compile(r'^\d+(\.\d+)?$')
 MESSAGE_REGEX = re.compile(
     r'(?:\d\:)?[a-zA-Z0-9]{32}(?:\,(?:\d{1,3}\:)?[a-zA-Z0-9]{32}){0,}'
 )

--- a/queuey/resources.py
+++ b/queuey/resources.py
@@ -34,7 +34,7 @@ def transform_stored_message(message):
     del message['metadata']
     message['partition'] = int(message['queue_name'].split(':')[-1])
     del message['queue_name']
-    message['timestamp'] = repr(message['timestamp'])
+    message['timestamp'] = str(message['timestamp'])
 
 
 class Root(object):
@@ -189,7 +189,7 @@ class Queue(object):
                                           msgs)
         rl = []
         for i, msg in enumerate(results):
-            rl.append({'key': msg[0], 'timestamp': repr(msg[1]),
+            rl.append({'key': msg[0], 'timestamp': str(msg[1]),
                        'partition': messages[i]['partition']})
         self.metlog.incr('%s.new_message' % self.application,
                          count=len(results))

--- a/queuey/resources.py
+++ b/queuey/resources.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import collections
-from decimal import Decimal
+from cdecimal import Decimal
 import re
 
 from pyramid.security import Allow

--- a/queuey/storage/__init__.py
+++ b/queuey/storage/__init__.py
@@ -129,8 +129,9 @@ class MessageQueueBackend(Interface):
         :param ttl: Time to Live in seconds for the message, after this
                     period the message should be unavilable
         :param timestamp: The timestamp to use for the message, should be
-                          a float of seconds since the epoch as time.time()
-                          would return. Defaults to the current time.
+                          either a `uuid.uuid1` or a decimal/float of seconds
+                          since the epoch as time.time() would return.
+                          Defaults to the current time.
 
         :returns: The message id and timestamp as a tuple
         :rtype: tuple

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-from decimal import Decimal
+from cdecimal import Decimal
 import inspect
 import uuid
 import time

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -124,6 +124,9 @@ class CassandraQueueBackend(object):
             if isinstance(start_at, basestring):
                 # Assume its a hex, transform to a datetime
                 start_at = uuid.UUID(hex=start_at)
+            else:
+                # Assume its a float/decimal, convert to UUID
+                start_at = convert_time_to_uuid(start_at)
 
             kwargs['column_start'] = start_at
 

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -20,6 +20,7 @@ ONE = pycassa.ConsistencyLevel.ONE
 QUORUM = pycassa.ConsistencyLevel.QUORUM
 LOCAL_QUORUM = pycassa.ConsistencyLevel.LOCAL_QUORUM
 EACH_QUORUM = pycassa.ConsistencyLevel.EACH_QUORUM
+DECIMAL_1E7 = Decimal('1e7')
 
 
 def parse_hosts(raw_hosts):
@@ -148,7 +149,7 @@ class CassandraQueueBackend(object):
                 obj = {
                     'message_id': msg_id.hex,
                     'timestamp': (Decimal(msg_id.time - 0x01b21dd213814000L) /
-                        Decimal('1e7')),
+                        DECIMAL_1E7),
                     'body': body,
                     'metadata': {},
                     'queue_name': queue_name[queue_name.find(':'):]
@@ -187,7 +188,7 @@ class CassandraQueueBackend(object):
         obj = {
             'message_id': msg_id.hex,
             'timestamp': (Decimal(msg_id.time - 0x01b21dd213814000L) /
-                Decimal('1e7')),
+                DECIMAL_1E7),
             'body': body,
             'metadata': {},
             'queue_name': queue_name[queue_name.find(':'):]
@@ -223,7 +224,7 @@ class CassandraQueueBackend(object):
         else:
             self.message_fam.insert(key=queue_name, columns={now: message},
                                     ttl=ttl, write_consistency_level=cl)
-        timestamp = Decimal(now.time - 0x01b21dd213814000L) / Decimal('1e7')
+        timestamp = Decimal(now.time - 0x01b21dd213814000L) / DECIMAL_1E7
         return now.hex, timestamp
 
     def push_batch(self, consistency, application_name, message_data):
@@ -238,8 +239,7 @@ class CassandraQueueBackend(object):
                          ttl=ttl)
             if metadata:
                 batch.insert(self.meta_fam, key=now, columns=metadata, ttl=ttl)
-            timestamp = (Decimal(now.time - 0x01b21dd213814000L) /
-                Decimal('1e7'))
+            timestamp = (Decimal(now.time - 0x01b21dd213814000L) / DECIMAL_1E7)
             msgs.append((now.hex, timestamp))
         batch.send()
         return msgs

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -137,7 +137,7 @@ class CassandraQueueBackend(object):
         if delay:
             cut_off = time.time() - delay
             # Turn it into time in ns, for efficient comparison
-            cut_off = cut_off * 1e9 / 100 + 0x01b21dd213814000L
+            cut_off = int(cut_off * 1e7) + 0x01b21dd213814000L
 
         result_list = []
         msg_hash = {}
@@ -147,7 +147,8 @@ class CassandraQueueBackend(object):
                     continue
                 obj = {
                     'message_id': msg_id.hex,
-                    'timestamp': (msg_id.time - 0x01b21dd213814000L) / 1e7,
+                    'timestamp': (Decimal(msg_id.time - 0x01b21dd213814000L) /
+                        Decimal('1e7')),
                     'body': body,
                     'metadata': {},
                     'queue_name': queue_name[queue_name.find(':'):]
@@ -185,7 +186,8 @@ class CassandraQueueBackend(object):
 
         obj = {
             'message_id': msg_id.hex,
-            'timestamp': (msg_id.time - 0x01b21dd213814000L) / 1e7,
+            'timestamp': (Decimal(msg_id.time - 0x01b21dd213814000L) /
+                Decimal('1e7')),
             'body': body,
             'metadata': {},
             'queue_name': queue_name[queue_name.find(':'):]
@@ -221,7 +223,7 @@ class CassandraQueueBackend(object):
         else:
             self.message_fam.insert(key=queue_name, columns={now: message},
                                     ttl=ttl, write_consistency_level=cl)
-        timestamp = (now.time - 0x01b21dd213814000L) / 1e7
+        timestamp = Decimal(now.time - 0x01b21dd213814000L) / Decimal('1e7')
         return now.hex, timestamp
 
     def push_batch(self, consistency, application_name, message_data):
@@ -236,7 +238,8 @@ class CassandraQueueBackend(object):
                          ttl=ttl)
             if metadata:
                 batch.insert(self.meta_fam, key=now, columns=metadata, ttl=ttl)
-            timestamp = (now.time - 0x01b21dd213814000L) / 1e7
+            timestamp = (Decimal(now.time - 0x01b21dd213814000L) /
+                Decimal('1e7'))
             msgs.append((now.hex, timestamp))
         batch.send()
         return msgs

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
+from decimal import Decimal
 import inspect
 import uuid
 import time
@@ -165,9 +166,12 @@ class CassandraQueueBackend(object):
                  include_metadata=False):
         """Retrieve a single message"""
         cl = self.cl or self._get_cl(consistency)
-        if isinstance(message_id, str):
+        if isinstance(message_id, basestring):
             # Convert to uuid for lookup
             message_id = uuid.UUID(hex=message_id)
+        else:
+            # Assume its a float/decimal, convert to UUID
+            message_id = convert_time_to_uuid(message_id)
 
         kwargs = {
             'read_consistency_level': cl,
@@ -202,7 +206,7 @@ class CassandraQueueBackend(object):
         cl = self.cl or self._get_cl(consistency)
         if not timestamp:
             now = uuid.uuid1()
-        elif isinstance(timestamp, float):
+        elif isinstance(timestamp, (float, Decimal)):
             now = convert_time_to_uuid(timestamp, randomize=True)
         else:
             now = uuid.UUID(hex=timestamp)

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -121,7 +121,7 @@ class CassandraQueueBackend(object):
             kwargs['column_count'] = limit
 
         if start_at:
-            if isinstance(start_at, str):
+            if isinstance(start_at, basestring):
                 # Assume its a hex, transform to a datetime
                 start_at = uuid.UUID(hex=start_at)
 

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from collections import defaultdict
-from decimal import Decimal
+from cdecimal import Decimal
 import uuid
 import time
 

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -12,6 +12,8 @@ from queuey.storage import MessageQueueBackend
 from queuey.storage import MetadataBackend
 from queuey.storage.util import convert_time_to_uuid
 
+DECIMAL_1E7 = Decimal('1e7')
+
 # Queue's keyed by applciation_name + queue_name
 # Queues are just a list of Message objects
 message_store = defaultdict(list)
@@ -28,7 +30,7 @@ class Message(object):
         self.ttl = None
         self.expiration = None
         if ttl:
-            now = Decimal(self.id.time - 0x01b21dd213814000L) / Decimal('1e7')
+            now = Decimal(self.id.time - 0x01b21dd213814000L) / DECIMAL_1E7
             self.expiration = now + ttl
 
     def __eq__(self, other):
@@ -116,7 +118,7 @@ class MemoryQueueBackend(object):
                 obj = {
                     'message_id': msg.id.hex,
                     'timestamp': (Decimal(msg.id.time - 0x01b21dd213814000L) /
-                        Decimal('1e7')),
+                        DECIMAL_1E7),
                     'body': msg.body,
                     'metadata': {},
                     'queue_name': queue_name[queue_name.find(':'):]
@@ -155,7 +157,7 @@ class MemoryQueueBackend(object):
         obj = {
             'message_id': found.id.hex,
             'timestamp': (Decimal(found.id.time - 0x01b21dd213814000L) /
-                Decimal('1e7')),
+                DECIMAL_1E7),
             'body': found.body,
             'metadata': {},
             'queue_name': queue_name[queue_name.find(':'):]
@@ -176,7 +178,7 @@ class MemoryQueueBackend(object):
         msg = Message(id=now, body=message, ttl=ttl)
         if metadata:
             msg.metadata = metadata
-        timestamp = Decimal(msg.id.time - 0x01b21dd213814000L) / Decimal('1e7')
+        timestamp = Decimal(msg.id.time - 0x01b21dd213814000L) / DECIMAL_1E7
         queue_name = '%s:%s' % (application_name, queue_name)
         if msg in message_store[queue_name]:
             message_store[queue_name].remove(msg)
@@ -193,7 +195,7 @@ class MemoryQueueBackend(object):
                 msg.metadata = metadata
             message_store[qn].append(msg)
             timestamp = (Decimal(msg.id.time - 0x01b21dd213814000L) /
-                Decimal('1e7'))
+                DECIMAL_1E7)
             msgs.append((msg.id.hex, timestamp))
         return msgs
 

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -68,7 +68,7 @@ class MemoryQueueBackend(object):
                 # Assume its a hex, transform to a UUID
                 start_at = uuid.UUID(hex=start_at)
             else:
-                # Assume its a float, convert to UUID
+                # Assume its a float/decimal, convert to UUID
                 start_at = convert_time_to_uuid(start_at)
 
         queue_names = ['%s:%s' % (application_name, x) for x in queue_names]

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -28,7 +28,7 @@ class Message(object):
         self.ttl = None
         self.expiration = None
         if ttl:
-            now = (self.id.time - 0x01b21dd213814000L) / 1e7
+            now = Decimal(self.id.time - 0x01b21dd213814000L) / Decimal('1e7')
             self.expiration = now + ttl
 
     def __eq__(self, other):
@@ -74,7 +74,7 @@ class MemoryQueueBackend(object):
 
         queue_names = ['%s:%s' % (application_name, x) for x in queue_names]
         results = []
-        now = time.time()
+        now = Decimal(repr(time.time()))
         for queue_name in queue_names:
             msgs = message_store[queue_name]
             if not msgs:
@@ -115,7 +115,8 @@ class MemoryQueueBackend(object):
                     break
                 obj = {
                     'message_id': msg.id.hex,
-                    'timestamp': (msg.id.time - 0x01b21dd213814000L) / 1e7,
+                    'timestamp': (Decimal(msg.id.time - 0x01b21dd213814000L) /
+                        Decimal('1e7')),
                     'body': msg.body,
                     'metadata': {},
                     'queue_name': queue_name[queue_name.find(':'):]
@@ -146,13 +147,15 @@ class MemoryQueueBackend(object):
         if not found:
             return {}
 
-        if found.expiration and time.time() > found.expiration:
+        now = Decimal(repr(time.time()))
+        if found.expiration and now > found.expiration:
             queue.remove(found)
             return {}
 
         obj = {
             'message_id': found.id.hex,
-            'timestamp': (found.id.time - 0x01b21dd213814000L) / 1e7,
+            'timestamp': (Decimal(found.id.time - 0x01b21dd213814000L) /
+                Decimal('1e7')),
             'body': found.body,
             'metadata': {},
             'queue_name': queue_name[queue_name.find(':'):]
@@ -173,7 +176,7 @@ class MemoryQueueBackend(object):
         msg = Message(id=now, body=message, ttl=ttl)
         if metadata:
             msg.metadata = metadata
-        timestamp = (msg.id.time - 0x01b21dd213814000L) / 1e7
+        timestamp = Decimal(msg.id.time - 0x01b21dd213814000L) / Decimal('1e7')
         queue_name = '%s:%s' % (application_name, queue_name)
         if msg in message_store[queue_name]:
             message_store[queue_name].remove(msg)
@@ -189,7 +192,8 @@ class MemoryQueueBackend(object):
             if metadata:
                 msg.metadata = metadata
             message_store[qn].append(msg)
-            timestamp = (msg.id.time - 0x01b21dd213814000L) / 1e7
+            timestamp = (Decimal(msg.id.time - 0x01b21dd213814000L) /
+                Decimal('1e7'))
             msgs.append((msg.id.hex, timestamp))
         return msgs
 

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from collections import defaultdict
+from decimal import Decimal
 import uuid
 import time
 
@@ -127,11 +128,11 @@ class MemoryQueueBackend(object):
     def retrieve(self, consistency, application_name, queue_name, message_id,
                  include_metadata=False):
         """Retrieve a single message"""
-        if isinstance(message_id, str):
+        if isinstance(message_id, basestring):
             # Convert to uuid for lookup
             message_id = uuid.UUID(hex=message_id)
         else:
-            # Assume its a float, convert to UUID
+            # Assume its a float/decimal, convert to UUID
             message_id = convert_time_to_uuid(message_id)
 
         queue_name = '%s:%s' % (application_name, queue_name)
@@ -165,7 +166,7 @@ class MemoryQueueBackend(object):
         """Push a message onto the queue"""
         if not timestamp:
             now = uuid.uuid1()
-        elif isinstance(timestamp, float):
+        elif isinstance(timestamp, (float, Decimal)):
             now = convert_time_to_uuid(timestamp, randomize=True)
         else:
             now = uuid.UUID(hex=timestamp)

--- a/queuey/storage/memory.py
+++ b/queuey/storage/memory.py
@@ -64,7 +64,7 @@ class MemoryQueueBackend(object):
         order = -1 if order == 'descending' else 1
 
         if start_at:
-            if isinstance(start_at, str):
+            if isinstance(start_at, basestring):
                 # Assume its a hex, transform to a UUID
                 start_at = uuid.UUID(hex=start_at)
             else:

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -2,6 +2,15 @@
 from decimal import Decimal
 import random
 import uuid
+
+try:
+    decimal_from_float = Decimal.from_float
+except AttributeError:
+    # For Python < 2.7, use less precise repr() conversion,
+    # preserving 16 decimal digits
+    def decimal_from_float(value):
+        return Decimal(repr(value))
+
 # This function copied from pycassa, under MIT license
 # Copyright (c) 2009 Jonathan Hseu
 #
@@ -62,10 +71,10 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     """
     if isinstance(time_arg, uuid.UUID):
         return time_arg
-    if isinstance(time_arg, Decimal):
-        time_arg = float(time_arg)
+    if isinstance(time_arg, float):
+        time_arg = decimal_from_float(time_arg)
 
-    microseconds = int(time_arg * 1e6)
+    microseconds = int(time_arg * Decimal('1e6'))
 
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -1,4 +1,5 @@
 """Storage utility functions"""
+from decimal import Decimal
 import random
 import uuid
 # This function copied from pycassa, under MIT license
@@ -61,6 +62,8 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     """
     if isinstance(time_arg, uuid.UUID):
         return time_arg
+    if isinstance(time_arg, Decimal):
+        time_arg = float(time_arg)
 
     microseconds = int(time_arg * 1e6)
 

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -46,17 +46,16 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     with slice arguments, however, as the non-timestamp portions
     can be set to their lowest or highest possible values.
 
-    :param datetime:
+    :param time_arg:
       The time to use for the timestamp portion of the UUID.
-      Expected inputs to this would either be a :class:`datetime`
-      object or a timestamp with the same precision produced by
-      :meth:`time.time()`. That is, sub-second precision should
-      be below the decimal place.
-    :type datetime: :class:`datetime` or timestamp
+      Expected inputs to this would either be a :class:`decimal` object or
+      a timestamp with a precision of at most 100 nanoseconds.
+      Sub-second precision should be below the decimal place.
+    :type time_arg: :class:`decimal` or timestamp
 
     :param lowest_val:
       Whether the UUID produced should be the lowest possible value
-      UUID with the same timestamp as datetime or the highest possible
+      UUID with the same timestamp as time_arg or the highest possible
       value.
     :type lowest_val: bool
 

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -7,7 +7,7 @@ try:
     decimal_from_float = Decimal.from_float
 except AttributeError:
     # For Python < 2.7, use less precise repr() conversion,
-    # preserving 16 decimal digits
+    # preserving only 15 decimal digits
     def decimal_from_float(value):
         return Decimal(repr(value))
 

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -11,6 +11,8 @@ except AttributeError:
     def decimal_from_float(value):
         return Decimal(repr(value))
 
+DECIMAL_1E7 = Decimal('1e7')
+
 # This function copied from pycassa, under MIT license
 # Copyright (c) 2009 Jonathan Hseu
 #
@@ -73,7 +75,7 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     if isinstance(time_arg, float):
         time_arg = decimal_from_float(time_arg)
 
-    ns_100 = int(time_arg * Decimal('1e7'))
+    ns_100 = int(time_arg * DECIMAL_1E7)
 
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -74,11 +74,11 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     if isinstance(time_arg, float):
         time_arg = decimal_from_float(time_arg)
 
-    microseconds = int(time_arg * Decimal('1e6'))
+    ns_100 = int(time_arg * Decimal('1e7'))
 
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-    timestamp = int(microseconds * 10) + 0x01b21dd213814000L
+    timestamp = ns_100 + 0x01b21dd213814000L
 
     time_low = timestamp & 0xffffffffL
     time_mid = (timestamp >> 32L) & 0xffffL

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -1,15 +1,7 @@
 """Storage utility functions"""
-from decimal import Decimal
+from cdecimal import Decimal
 import random
 import uuid
-
-try:
-    decimal_from_float = Decimal.from_float
-except AttributeError:
-    # For Python < 2.7, use less precise repr() conversion,
-    # preserving only 15 decimal digits
-    def decimal_from_float(value):
-        return Decimal(repr(value))
 
 DECIMAL_1E7 = Decimal('1e7')
 
@@ -73,7 +65,7 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
     if isinstance(time_arg, uuid.UUID):
         return time_arg
     if isinstance(time_arg, float):
-        time_arg = decimal_from_float(time_arg)
+        time_arg = Decimal.from_float(time_arg)
 
     ns_100 = int(time_arg * DECIMAL_1E7)
 

--- a/queuey/storage/util.py
+++ b/queuey/storage/util.py
@@ -25,7 +25,7 @@ DECIMAL_1E7 = Decimal('1e7')
 # DEALINGS IN THE SOFTWARE.
 
 
-def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma: nocover
+def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):
     """
     Converts a timestamp to a type 1 :class:`uuid.UUID`.
 
@@ -97,7 +97,7 @@ def convert_time_to_uuid(time_arg, lowest_val=True, randomize=False):  # pragma:
             clock_seq_hi_variant = 0 & 0x3fL  # The two most significant bits
                                               # will be 0 and 1, no matter what
             node = 0x808080808080L  # 48 bits
-        else:
+        else:  # pragma: nocover
             # Make the highest value UUID with the same timestamp
             clock_seq_low = 0x7fL
             clock_seq_hi_variant = 0x3fL  # The two most significant bits will

--- a/queuey/tests/test_integrated.py
+++ b/queuey/tests/test_integrated.py
@@ -56,7 +56,7 @@ class TestQueueyBaseApp(unittest.TestCase):
         result = json.loads(resp.body)
         eq_('ok', result['status'])
 
-    def test_queue_and_get_since_ts(self):
+    def test_queue_and_get_since_message_id(self):
         app, queue_name = self._make_app_queue()
 
         # Post a message
@@ -72,7 +72,7 @@ class TestQueueyBaseApp(unittest.TestCase):
                  'Hello there! 3', headers=auth_header)
 
         # Fetch the messages
-        resp = app.get('/v1/queuey/' + queue_name, {'since': msg_ts},
+        resp = app.get('/v1/queuey/' + queue_name, {'since': msg_id},
                        headers=auth_header)
         result = json.loads(resp.body)
         if len(result['messages']) != 2:

--- a/queuey/tests/test_integrated.py
+++ b/queuey/tests/test_integrated.py
@@ -76,12 +76,9 @@ class TestQueueyBaseApp(unittest.TestCase):
                        headers=auth_header)
         result = json.loads(resp.body)
         if len(result['messages']) != 2:
+            print msg_id
             print msg_ts
             print result
-            from queuey.storage.util import convert_time_to_uuid
-            import uuid
-            print 'query  ', convert_time_to_uuid(float(msg_ts)).time
-            print 'message', uuid.UUID(msg_id).time
 
         eq_(2, len(result['messages']))
         msg = result['messages'][0]

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ reqs = [
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:
     reqs.extend([
+        'cdecimal',
         'gunicorn',
         'pyramid',
         'webtest',


### PR DESCRIPTION
Heavy-handed fix for precision lost of message['timestamp'] values - https://github.com/mozilla-services/queuey/issues/5
