### PR TITLE
Increase message TTL to a maximum of a bit more than a year

### DIFF
--- a/queuey/tests/test_integrated.py
+++ b/queuey/tests/test_integrated.py
@@ -358,6 +358,25 @@ class TestQueueyBaseApp(unittest.TestCase):
         eq_('Yo', result['messages'][0]['body'])
         eq_('Yo', result['messages'][1]['body'])
 
+    def test_high_ttl(self):
+        app, queue_name = self._make_app_queue()
+        h = auth_header.copy()
+        h['X-TTL'] = str(2 ** 25)
+        resp = app.post('/v1/queuey/' + queue_name, 'Hello there!', headers=h)
+        result = json.loads(resp.body)
+        eq_(201, resp.status_int)
+        eq_('ok', result['status'])
+
+    def test_bad_ttl(self):
+        app, queue_name = self._make_app_queue()
+        h = auth_header.copy()
+        h['X-TTL'] = '0'
+        resp = app.post('/v1/queuey/' + queue_name, 'Hello there!', headers=h,
+                status=400)
+        result = json.loads(resp.body)
+        eq_('error', result['status'])
+        eq_(['ttl'], result['error_msg'].keys())
+
     def test_bad_partition(self):
         app, queue_name = self._make_app_queue()
         h = auth_header.copy()

--- a/queuey/validators.py
+++ b/queuey/validators.py
@@ -96,7 +96,7 @@ class Message(colander.MappingSchema):
     partition = colander.SchemaNode(colander.Int(), missing=None,
                                     validator=max_queue_partition)
     ttl = colander.SchemaNode(colander.Int(), missing=60 * 60 * 24 * 3,
-                              validator=colander.Range(1, 60 * 60 * 24 * 3))
+                              validator=colander.Range(1, 2 ** 25))
 
 
 class MessageList(colander.SequenceSchema):


### PR DESCRIPTION
Cassandra allows the TTL to be of type Int32Type, but the transport layer caps it before that, somewhere between 2**29 and 2**30. 2**25 meaning a bit more than a year sounded just as well to me.

This fixes https://github.com/mozilla-services/queuey/issues/4
