### PR TITLE
Enforce message keys to be v1 UUIDs.

### DIFF
--- a/etc/cassandra/message_schema.txt
+++ b/etc/cassandra/message_schema.txt
@@ -5,14 +5,14 @@ create keyspace MessageStore
 use MessageStore;
 
 create column family Messages
-    with comparator = UUIDType
+    with comparator = TimeUUIDType
     and key_validation_class = UTF8Type
     and default_validation_class = UTF8Type
     and rows_cached = 100;
 
 create column family MessageMetadata
     with comparator = UTF8Type
-    and key_validation_class = UUIDType
+    and key_validation_class = TimeUUIDType
     and rows_cached = 1000
     and default_validation_class = UTF8Type
     and compression_options = [{

--- a/queuey/storage/cassandra.py
+++ b/queuey/storage/cassandra.py
@@ -181,7 +181,7 @@ class CassandraQueueBackend(object):
         queue_name = '%s:%s' % (application_name, queue_name)
         try:
             results = self.message_fam.get(key=queue_name, **kwargs)
-        except pycassa.NotFoundException:
+        except (pycassa.NotFoundException, pycassa.InvalidRequestException):
             return {}
         msg_id, body = results.items()[0]
 


### PR DESCRIPTION
C\* has TimeUUIDs. To ensure proper sorting, it makes sense to me to restrict message ids this way.

The exception change covers `queuey.tests.test_cassandra:TestCassandraStore.test_no_message`, which uses the queue name (a v4 UUID) to ask for a non-existing message.
